### PR TITLE
Circumvention on TAP output garbage

### DIFF
--- a/pycotap/__init__.py
+++ b/pycotap/__init__.py
@@ -104,7 +104,7 @@ class TAPTestResult(unittest.TestResult):
             self.print_raw("      File-Content: " + base64.b64encode(output) + "\n")
             self.print_raw("  ...\n")
           else:
-            self.print_raw("# " + output.rstrip().replace("\n", "\n# ") + "\n")
+            self.print_raw("# " + output.rstrip().replace("\n", "\n# ").replace("\0", "") + "\n")
         log.truncate(0)
 
   def addSuccess(self, test):


### PR DESCRIPTION
# Warning
**This is a circumvention!**

Fix #9, sometimes `\0` are printed between `# ` and the message from test output. This fix removes them from output before printing it.