### PR TITLE
Reset log stream position after truncating

### DIFF
--- a/pycotap/__init__.py
+++ b/pycotap/__init__.py
@@ -104,7 +104,7 @@ class TAPTestResult(unittest.TestResult):
             self.print_raw("      File-Content: " + base64.b64encode(output) + "\n")
             self.print_raw("  ...\n")
           else:
-            self.print_raw("# " + output.rstrip().replace("\n", "\n# ").replace("\0", "") + "\n")
+            self.print_raw("# " + output.rstrip().replace("\n", "\n# ") + "\n")
         log.truncate(0)
 
   def addSuccess(self, test):

--- a/pycotap/__init__.py
+++ b/pycotap/__init__.py
@@ -104,8 +104,6 @@ class TAPTestResult(unittest.TestResult):
             self.print_raw("      File-Content: " + base64.b64encode(output) + "\n")
             self.print_raw("  ...\n")
           else:
-            # FIXME: As reported in  #9, sometimes \0 is printed in the output. 
-            # Need to investigate why this happens. As a temporary workaround, filter out the NULL bytes.
             self.print_raw("# " + output.rstrip().replace("\n", "\n# ").replace("\0", "") + "\n")
         log.truncate(0)
 

--- a/pycotap/__init__.py
+++ b/pycotap/__init__.py
@@ -106,6 +106,7 @@ class TAPTestResult(unittest.TestResult):
           else:
             self.print_raw("# " + output.rstrip().replace("\n", "\n# ") + "\n")
         log.truncate(0)
+        log.seek(0)
 
   def addSuccess(self, test):
     super(TAPTestResult, self).addSuccess(test)


### PR DESCRIPTION
At the end of each test, any output that has been buffered in the
StringIO instance(s) that have been set on sys.stdout and sys.stderr is
written to the real output stream (typically the original sys.stdout).
The StringIO is then truncated, ready for the next test.

However, [the truncate() documentation][0] reminds us that, just as in
the underlying POSIX truncate() call:

> The current stream position isn’t changed.

So if the first test has written 3 characters to the mock stdout, after
we truncate the stream, the current stream position remains at 3, not 0.
Then, when the next test writes to the stream, bytes 0-2 are filled with
NUL. You can see this clearly with the following test program:

    #!/usr/bin/python3
    import io

    x = io.StringIO()
    x.write("abc")
    print("file size after truncate:", x.truncate(0))
    print("stream position after truncate:", x.tell())
    print("value after truncate: %r" % x.getvalue())
    x.write("y")
    print("stream position after write:", x.tell())
    print("buffer after write: %r" % x.getvalue())

Call seek(0) to reset the stream position after truncating it.

Fixes https://github.com/remko/pycotap/issues/9 (for real).

[0]: https://docs.python.org/3/library/io.html#io.IOBase.truncate